### PR TITLE
Handle namespaced rdf:rdf tag in parseRssXml method

### DIFF
--- a/mycuration/src/main/java/com/phicdy/mycuration/rss/RssParser.java
+++ b/mycuration/src/main/java/com/phicdy/mycuration/rss/RssParser.java
@@ -43,7 +43,7 @@ public class RssParser {
 			public void run() {
 				try {
 					Document document = Jsoup.connect(baseUrl).get();
-					if (!document.getElementsByTag("rdf").isEmpty()) {
+					if (!document.getElementsByTag("rdf").isEmpty() || !document.getElementsByTag("rdf:rdf").isEmpty()) {
 						// RSS 1.0
 						Elements links = document.getElementsByTag("link");
 						String siteUrl = null;


### PR DESCRIPTION
Current code (before this PR) cannot handle following feed content, so I added code to detect `<rdf:rdf` tag

http://b.hatena.ne.jp/hotentry/it.rss
```
<!--?xml version="1.0" encoding="UTF-8"?-->
<html>
 <head></head>
 <body>
  <rdf:rdf xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:taxo="http://purl.org/rss/1.0/modules/taxonomy/" xmlns:opensearch="http://a9.com/-/spec/opensearchrss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:hatena="http://www.hatena.ne.jp/info/xmlns#" xmlns:media="http://search.yahoo.com/mrss"> 
   <channel rdf:about="http://b.hatena.ne.jp/hotentry/it"> 
    <title>はてなブックマーク - 人気エントリー - テクノロジー</title> 
    <link>http://b.hatena.ne.jp/hotentry/it 
    <description>
...
```