### PR TITLE
Bug fix: Pass curation ID to avoid crash when presenter is null

### DIFF
--- a/mycuration/src/main/java/com/phicdy/mycuration/view/activity/TopActivity.java
+++ b/mycuration/src/main/java/com/phicdy/mycuration/view/activity/TopActivity.java
@@ -250,10 +250,10 @@ public class TopActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onCurationListClicked(int position) {
+    public void onCurationListClicked(int curationId) {
         Intent intent = new Intent();
         intent.setClass(getApplicationContext(), ArticlesListActivity.class);
-        intent.putExtra(CURATION_ID, curationFragment.getCurationIdAtPosition(position));
+        intent.putExtra(CURATION_ID, curationId);
         startActivity(intent);
     }
 

--- a/mycuration/src/main/java/com/phicdy/mycuration/view/fragment/CurationListFragment.java
+++ b/mycuration/src/main/java/com/phicdy/mycuration/view/fragment/CurationListFragment.java
@@ -91,7 +91,10 @@ public class CurationListFragment extends Fragment implements CurationListView {
             @Override
             public void onItemClick(AdapterView<?> parent, View view,
                                     int position, long id) {
-                mListener.onCurationListClicked(position);
+                Curation curation = curationAt(position);
+                if (curation != null) {
+                    mListener.onCurationListClicked(curation.getId());
+                }
             }
         });
     }
@@ -126,10 +129,6 @@ public class CurationListFragment extends Fragment implements CurationListView {
     public void onDetach() {
         super.onDetach();
         mListener = null;
-    }
-
-    public int getCurationIdAtPosition (int position) {
-        return presenter.getCurationIdAt(position);
     }
 
     @Override
@@ -182,7 +181,7 @@ public class CurationListFragment extends Fragment implements CurationListView {
     }
 
     public interface OnCurationListFragmentListener {
-        void onCurationListClicked(int position);
+        void onCurationListClicked(int curationId);
     }
 
     class CurationListAdapter extends ArrayAdapter<Curation> {


### PR DESCRIPTION
When user goes to other page and then go back to top, it has crash case when user taps curation. Because presenter was not initialized yet. 