### PR TITLE
Bug fix: Check fragment is attached before getString()

### DIFF
--- a/mycuration/src/main/java/com/phicdy/mycuration/view/fragment/ArticlesListFragment.java
+++ b/mycuration/src/main/java/com/phicdy/mycuration/view/fragment/ArticlesListFragment.java
@@ -264,7 +264,7 @@ public class ArticlesListFragment extends Fragment implements ArticleListView {
 
     @Override
     public void showShareUi(@NonNull String url) {
-        GATrackerHelper.sendEvent(getString(R.string.share_article));
+        if (isAdded()) GATrackerHelper.sendEvent(getString(R.string.share_article));
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
         intent.putExtra(Intent.EXTRA_TEXT, url);


### PR DESCRIPTION
It causes IllegalStateException
https://stackoverflow.com/questions/28672883/java-lang-illegalstateexception-fragment-not-attached-to-activity