### PR TITLE
RSS Parse: Skip canonical value check in second parse

### DIFF
--- a/mycuration/src/main/java/com/phicdy/mycuration/task/NetworkTaskManager.java
+++ b/mycuration/src/main/java/com/phicdy/mycuration/task/NetworkTaskManager.java
@@ -111,7 +111,7 @@ public class NetworkTaskManager {
 	public void addNewFeed(String feedUrl) {
 		final String requestUrl = UrlUtil.removeUrlParameter(feedUrl);
         RssParser parser = new RssParser(context);
-		parser.parseRssXml(requestUrl);
+		parser.parseRssXml(requestUrl, true);
 	}
 
 


### PR DESCRIPTION
## Background

If MyCuration parses the HTML URL in canonical setting that is same with original one, it parses same URL and then skip parse

e.g. 
1. Check http://hoge.com (HTML, not RSS and canonical is http://hoge.com)
2. MyCuration detects HTML and canonical
3. MyCuration tries to parse http://hoge.com from canonical setting
4. MyCuration detects HTML and canonical, it skips parse and show error toast

## Solution

In step3, skip to check canonical setting and then parse HTML