### PR TITLE
Bug fix: When RSS is hidden before target RSS, other RSS becomes the …

### DIFF
--- a/mycuration/src/androidTest/java/com/phicdy/mycuration/uitest/EditFeedTitleTest.java
+++ b/mycuration/src/androidTest/java/com/phicdy/mycuration/uitest/EditFeedTitleTest.java
@@ -1,0 +1,140 @@
+package com.phicdy.mycuration.uitest;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Rect;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SdkSuppress;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.By;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject2;
+import android.support.test.uiautomator.Until;
+
+import com.phicdy.mycuration.BuildConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static junit.framework.Assert.fail;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+@SdkSuppress(minSdkVersion = 18)
+public class EditFeedTitleTest extends UiTest {
+
+    @Before
+    public void setup() {
+        super.setup();
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
+    }
+
+    @Test
+    public void editYahooNewsTitle() {
+        UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        // Launch MainActivity
+        Context context = InstrumentationRegistry.getContext();
+        Intent intent = context.getPackageManager().getLaunchIntentForPackage(BuildConfig.APPLICATION_ID);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        context.startActivity(intent);
+
+        // Go to feed tab
+        List<UiObject2> tabs = device.wait(Until.findObjects(
+                By.clazz(android.support.v7.app.ActionBar.Tab.class)), 15000);
+        if (tabs == null) fail("Tab was not found");
+        if (tabs.size() != 3) fail("Tab size was invalid, size: " + tabs.size());
+        tabs.get(1).click();
+
+        // Click plus button
+        String[] urls = new String[]{
+                "http://news.yahoo.co.jp/pickup/rss.xml",
+                "https://news.yahoo.co.jp/pickup/world/rss.xml"
+        };
+        for (String url : urls) {
+            UiObject2 plusButton = device.findObject(By.res(BuildConfig.APPLICATION_ID, "add"));
+            if (plusButton == null) fail("Plus button was not found");
+            plusButton.click();
+
+            // Show edit text for URL if needed
+            UiObject2 searchButton = device.wait(Until.findObject(
+                    By.res(BuildConfig.APPLICATION_ID, "search_button")), 5000);
+            if (searchButton != null) searchButton.click();
+
+            // Open yahoo RSS URL
+            UiObject2 urlEditText = device.wait(Until.findObject(
+                    By.res(BuildConfig.APPLICATION_ID, "search_src_text")), 5000);
+            if (urlEditText == null) fail("URL edit text was not found");
+            urlEditText.setText(url);
+            device.pressEnter();
+        }
+
+        // Assert yahoo RSS was added
+        List<UiObject2> feedTitles = device.wait(Until.findObjects(
+                By.res(BuildConfig.APPLICATION_ID, "feedTitle")), 5000);
+        if (feedTitles == null) fail("Feed was not found");
+        // Feed title list includes show/hide option row, the size is 2
+        if (feedTitles.size() != 3) fail("Feed was not added");
+        assertThat(feedTitles.get(0).getText(), is("Yahoo!ニュース・トピックス - 主要"));
+        assertThat(feedTitles.get(1).getText(), is("Yahoo!ニュース・トピックス - 国際"));
+        assertThat(feedTitles.get(2).getText(), is("全てのRSSを表示"));
+
+        // Read all of the articles of first RSS
+        feedTitles.get(0).clickAndWait(Until.newWindow(), 5000);
+        UiObject2 fab = device.wait(Until.findObject(
+                By.res(BuildConfig.APPLICATION_ID, "fab")), 5000);
+        fab.click();
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        fab.click();
+
+        // Go back to main UI if needed
+        fab = device.wait(Until.findObject(
+                By.res(BuildConfig.APPLICATION_ID, "fab")), 5000);
+        if (fab != null) device.pressBack();
+
+        // Check main UI
+        feedTitles = device.wait(Until.findObjects(
+                By.res(BuildConfig.APPLICATION_ID, "feedTitle")), 5000);
+        if (feedTitles == null) fail("Feed was not found");
+        if (feedTitles.size() != 2) fail("Feed was not added");
+        assertThat(feedTitles.get(0).getText(), is("Yahoo!ニュース・トピックス - 国際"));
+        assertThat(feedTitles.get(1).getText(), is("全てのRSSを表示"));
+
+        // Edit title
+        Rect filterRect = feedTitles.get(0).getVisibleBounds();
+        device.swipe(filterRect.centerX(), filterRect.centerY(),
+                filterRect.centerX(), filterRect.centerY(), 100);
+        UiObject2 edit = device.wait(Until.findObject(
+                By.text("RSSのタイトルを編集")), 5000);
+        if (edit == null) fail("Edit menu was not found");
+        edit.click();
+        UiObject2 currentTitle = device.wait(Until.findObject(
+                By.res(BuildConfig.APPLICATION_ID, "editFeedTitle")), 3000);
+        if (currentTitle == null) fail("Current title was not found");
+        assertThat(currentTitle.getText(), is("Yahoo!ニュース・トピックス - 国際"));
+        currentTitle.setText("test");
+        UiObject2 saveButton = device.findObject(By.res("android:id/button1"));
+        if (saveButton == null) fail("Save button was not found");
+        saveButton.click();
+
+        // Check edited title
+        feedTitles = device.wait(Until.findObjects(
+                By.res(BuildConfig.APPLICATION_ID, "feedTitle")), 5000);
+        if (feedTitles == null) fail("Feed was not found");
+        if (feedTitles.size() != 2) fail("Feed was not added");
+        assertThat(feedTitles.get(0).getText(), is("test"));
+    }
+}

--- a/mycuration/src/main/java/com/phicdy/mycuration/presenter/FeedListPresenter.java
+++ b/mycuration/src/main/java/com/phicdy/mycuration/presenter/FeedListPresenter.java
@@ -111,10 +111,12 @@ public class FeedListPresenter implements Presenter {
         if (position < 0 || feeds == null || position > feeds.size()-1) {
             return "";
         }
+        String title;
         if (isHided) {
-            feeds.get(position).getTitle();
+            title = feeds.get(position).getTitle();
+        } else {
+            title = allFeeds.get(position).getTitle();
         }
-        String title = allFeeds.get(position).getTitle();
         if (title == null) title = "";
         return title;
     }

--- a/mycuration/src/test/java/com/phicdy/mycuration/presenter/FeedListPresenterTest.java
+++ b/mycuration/src/test/java/com/phicdy/mycuration/presenter/FeedListPresenterTest.java
@@ -1,0 +1,174 @@
+package com.phicdy.mycuration.presenter;
+
+
+import android.support.annotation.NonNull;
+
+import com.phicdy.mycuration.db.DatabaseAdapter;
+import com.phicdy.mycuration.rss.Feed;
+import com.phicdy.mycuration.rss.UnreadCountManager;
+import com.phicdy.mycuration.task.NetworkTaskManager;
+import com.phicdy.mycuration.view.FeedListView;
+import com.phicdy.mycuration.view.fragment.FeedListFragment;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class FeedListPresenterTest {
+
+    private FeedListPresenter presenter;
+    private DatabaseAdapter adapter;
+    private NetworkTaskManager networkTaskManager;
+    private UnreadCountManager unreadCountManager;
+    private MockView view;
+
+    private static final String FIRST_RSS_TITLE = "rss1";
+    private static final String SECOND_RSS_TITLE = "rss2";
+    private static final int FIRST_RSS_ID = 0;
+    private static final int SECOND_RSS_ID = 1;
+
+    private static final int FIRST_RSS_POSITION = 0;
+    private static final int SECOND_RSS_POSITION = 1;
+    private static final int HIDE_OPTION_POSITION_WHEN_HIDDEN = 1;
+
+    @Before
+    public void setup() {
+        adapter = Mockito.mock(DatabaseAdapter.class);
+        ArrayList<Feed> allFeeds = new ArrayList<>();
+        allFeeds.add(new Feed(FIRST_RSS_ID, FIRST_RSS_TITLE, "", "", "", 0));
+        allFeeds.add(new Feed(SECOND_RSS_ID, SECOND_RSS_TITLE, "", "", "", 1));
+        Mockito.when(adapter.getAllFeedsWithNumOfUnreadArticles()).thenReturn(allFeeds);
+        networkTaskManager = Mockito.mock(NetworkTaskManager.class);
+        unreadCountManager = Mockito.mock(UnreadCountManager.class);
+        Mockito.when(unreadCountManager.getUnreadCount(FIRST_RSS_ID))
+                .thenReturn(0);
+        Mockito.when(unreadCountManager.getUnreadCount(SECOND_RSS_ID))
+                .thenReturn(1);
+        Mockito.when(unreadCountManager.getUnreadCount(Feed.DEFAULT_FEED_ID)).thenReturn(-1);
+        presenter = new FeedListPresenter(adapter, networkTaskManager, unreadCountManager);
+        view = new MockView();
+        presenter.setView(view);
+    }
+
+    @Test
+    public void WhenFirstRssIsHiddenThenFirstEditTitleWillBeSecondRss() {
+        // Default hidden option is enaled
+        presenter.create();
+        presenter.resume();
+        presenter.onEditFeedMenuClicked(FIRST_RSS_POSITION);
+        assertThat(view.editTitle, is(SECOND_RSS_TITLE));
+    }
+
+    @Test
+    public void WhenRssIsNotHiddenThenFirstEditTitleWillBeFirstRss() {
+        presenter.create();
+        presenter.resume();
+        // Disale hidden option
+        presenter.onFeedListClicked(HIDE_OPTION_POSITION_WHEN_HIDDEN, new FeedListFragment.OnFeedListFragmentListener() {
+            @Override
+            public void onListClicked(int feedId) {
+            }
+
+            @Override
+            public void onAllUnreadClicked() {
+            }
+        });
+        presenter.onEditFeedMenuClicked(FIRST_RSS_POSITION);
+        assertThat(view.editTitle, is(FIRST_RSS_TITLE));
+    }
+
+    private class MockView implements FeedListView {
+
+        private String editTitle;
+
+        @Override
+        public void showDeleteFeedAlertDialog(int position) {
+
+        }
+
+        @Override
+        public void showEditTitleDialog(int position, @NonNull String feedTitle) {
+            this.editTitle = feedTitle;
+        }
+
+        @Override
+        public void setRefreshing(boolean doScroll) {
+
+        }
+
+        @Override
+        public void init(@NonNull ArrayList<Feed> feeds) {
+
+        }
+
+        @Override
+        public void setTotalUnreadCount(int count) {
+
+        }
+
+        @Override
+        public void onRefreshCompleted() {
+
+        }
+
+        @Override
+        public void showEditFeedTitleEmptyErrorToast() {
+
+        }
+
+        @Override
+        public void showEditFeedFailToast() {
+
+        }
+
+        @Override
+        public void showEditFeedSuccessToast() {
+
+        }
+
+        @Override
+        public void showDeleteSuccessToast() {
+
+        }
+
+        @Override
+        public void showDeleteFailToast() {
+
+        }
+
+        @Override
+        public void showAddFeedSuccessToast() {
+
+        }
+
+        @Override
+        public void showGenericAddFeedErrorToast() {
+
+        }
+
+        @Override
+        public void showInvalidUrlAddFeedErrorToast() {
+
+        }
+
+        @Override
+        public void notifyDataSetChanged() {
+
+        }
+
+        @Override
+        public void showAllUnreadView() {
+
+        }
+
+        @Override
+        public void hideAllUnreadView() {
+
+        }
+    }
+}


### PR DESCRIPTION
…target to edit

## Background

When some RSSes were hidden, not target RSS will be edited.

## Solution

If hidden option is enabled, get RSS from RSS list that has unread articles

## Test Result

`EditFeedTitleTest` passed