### PR TITLE
RSS Search: Fix crash when search the word

### DIFF
--- a/mycuration/src/main/java/com/phicdy/mycuration/presentation/view/activity/FeedSearchActivity.kt
+++ b/mycuration/src/main/java/com/phicdy/mycuration/presentation/view/activity/FeedSearchActivity.kt
@@ -74,7 +74,8 @@ class FeedSearchActivity : AppCompatActivity(), FeedSearchView {
                 return false
             }
 
-            override fun onPageStarted(view: WebView, url: String, favicon: Bitmap) {
+            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                if (url == null) return
                 setSearchViewTextFrom(url)
             }
         })


### PR DESCRIPTION
It overrided onPageStarted() as non-null parameters, but in fact, they are nullable