### PR TITLE
Observe in onViewCrated

### DIFF
--- a/feature_article_list/src/main/java/com/phicdy/mycuration/articlelist/ArticlesListFragment.kt
+++ b/feature_article_list/src/main/java/com/phicdy/mycuration/articlelist/ArticlesListFragment.kt
@@ -111,8 +111,8 @@ class ArticlesListFragment : Fragment(), ArticleListAdapter.Listener {
         fun finish()
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         // Set swipe direction
         val prefMgr = PreferenceHelper

--- a/feature_article_list/src/main/java/com/phicdy/mycuration/articlelist/FavoriteArticlesListFragment.kt
+++ b/feature_article_list/src/main/java/com/phicdy/mycuration/articlelist/FavoriteArticlesListFragment.kt
@@ -81,8 +81,8 @@ class FavoriteArticlesListFragment : Fragment(), ArticleListAdapter.Listener {
         fun finish()
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         articleListStore.state.observe(viewLifecycleOwner, Observer<List<ArticleItem>> {
             if (it.isEmpty()) {

--- a/feature_curated_article_list/src/main/java/com/phicdy/mycuration/curatedarticlelist/CuratedArticlesListFragment.kt
+++ b/feature_curated_article_list/src/main/java/com/phicdy/mycuration/curatedarticlelist/CuratedArticlesListFragment.kt
@@ -67,7 +67,7 @@ class CuratedArticlesListFragment : Fragment(), CoroutineScope, CuratedArticleLi
         }
     }
 
-    private lateinit var job: Job
+    private val job = Job()
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Main
 
@@ -101,9 +101,8 @@ class CuratedArticlesListFragment : Fragment(), CoroutineScope, CuratedArticleLi
         fun finish()
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        job = Job()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         curatedArticleListStore.state.observe(viewLifecycleOwner, Observer<List<CuratedArticleItem>> {
             if (it.isEmpty()) {


### PR DESCRIPTION
To fix crash `    java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()`